### PR TITLE
Add FontsWiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Links marked with 🤖 are AI resources.
 - [Nerd Fonts](https://www.nerdfonts.com/font-downloads) - advanced fonts for programmers with special glyphs
 - [Typefaces.today](https://typefaces.today/) - handpicked typefaces for your creative projects  
 - [Fontshare](https://www.fontshare.com/) - a free fonts service from the Indian Type Foundry (ITF), making quality fonts accessible to all  
+- [FontsWiki](https://fontswiki.com/) - free typography resource with font downloads, pairing guides, and font-in-use references for logos, films, games, and design projects
 - [DaFont](https://www.dafont.com/) - archive of freely downloadable fonts
 - [YouWorkForThem](https://www.youworkforthem.com/) - free high-quality fonts and graphics
 - [Type Department](https://type-department.com/) - provides designers and brands with high-quality fonts that ignite design solutions and command attention


### PR DESCRIPTION
Adds FontsWiki to the Typography section.

FontsWiki is a free typography resource with font downloads, pairing guides, and font-in-use references for logos, films, games, and design projects.

Link: https://fontswiki.com/