### PR TITLE
Add UIZZE UI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Links marked with 🤖 are AI resources.
 - [BentoGrids](https://bentogrids.com/) - a curated collection of bento designs for your inspiration
 - [App Motion](https://appmotion.design/) - explore the best, hand-picked app motion design
 - [Mobbin](https://mobbin.com/discover/apps/ios) - the world’s largest mobile and web design library
+- [UIZZE](https://uizze.com/mobbin-alternative) - Browse public web and iOS UI references in UIZZE. Search real product screens, flows, and UI elements, then connect paid agent tools when you need them.
 - [Land-book](https://land-book.com/) - hand-picked website design inspiration
 - [BrandGuidelines](https://www.brandguidelines.net/) - handpicked, curated brand guidelines from around the world  
 - [Deck.Gallery](https://www.deck.gallery/) - explore curated, beautifully designed presentation decks, slides, keynotes, and guidelines, all chosen for their exceptional design quality  


### PR DESCRIPTION
## What changed

Adds UIZZE to **Inspiration & Community** beside the catalog's other UI-reference libraries.

The linked page is UIZZE's public Mobbin-alternative route. The description is copied verbatim from its live metadata and states the public-browsing versus paid-agent-tools boundary.

## Validation

- `https://uizze.com/mobbin-alternative` returns HTTP 200.
- `npm run check-links` completed; the UIZZE URL is unique. The checker reports four duplicate URLs already present on the base branch.
- `git diff --check` passes.
