### PR TITLE
Use the UIZZE homepage and current catalogue description

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Links marked with 🤖 are AI resources.
 - [BentoGrids](https://bentogrids.com/) - a curated collection of bento designs for your inspiration
 - [App Motion](https://appmotion.design/) - explore the best, hand-picked app motion design
 - [Mobbin](https://mobbin.com/discover/apps/ios) - the world’s largest mobile and web design library
-- [UIZZE](https://uizze.com/mobbin-alternative) - Browse public web and iOS UI references in UIZZE. Search real product screens, flows, and UI elements, then connect paid agent tools when you need them.
+- [UIZZE](https://uizze.com) - Browse 800,000+ real web and iOS screens, flows, and UI elements to replace generic interface defaults with product-specific design decisions.
 - [Land-book](https://land-book.com/) - hand-picked website design inspiration
 - [BrandGuidelines](https://www.brandguidelines.net/) - handpicked, curated brand guidelines from around the world  
 - [Deck.Gallery](https://www.deck.gallery/) - explore curated, beautifully designed presentation decks, slides, keynotes, and guidelines, all chosen for their exceptional design quality  


### PR DESCRIPTION
Small follow-up to the merged UIZZE entry:

- uses the canonical plain homepage
- describes the current free catalogue directly
- removes pricing language from the directory copy

Disclosure: I maintain UIZZE/Aislon.